### PR TITLE
Camera tracking pipe speed

### DIFF
--- a/Assets/Scripts/Controllers/Player/PlayerController.cs
+++ b/Assets/Scripts/Controllers/Player/PlayerController.cs
@@ -53,6 +53,7 @@ namespace GGJ2021
         private GameObject jumpVFX;
 
         public bool goingThroughPipe = false;
+        public float currentPipeSpeed = 20f;
 
         private float screenH;
         private float screenW;
@@ -188,8 +189,9 @@ namespace GGJ2021
             if (playerPhysics.isDashing)
             {
                 goingThroughPipe = true;
+                currentPipeSpeed = 25f;
                 StateMachine.ForceNextState(new PlayerStatePipe(this));
-                pipe.MoveObjectThroughPipe(transform, 20f, () => goingThroughPipe = false, pipeType);
+                pipe.MoveObjectThroughPipe(transform, currentPipeSpeed, () => goingThroughPipe = false, pipeType);
             }
         }
 

--- a/Assets/Scripts/Tilemap/Pipe.cs
+++ b/Assets/Scripts/Tilemap/Pipe.cs
@@ -64,6 +64,7 @@ namespace GGJ2021
         public GameObject BakedObject;
 
         [Header("Debug Variables")]
+        public bool EnableDebugLogs = false;
         public Transform DebugObjectThroughPipe;
         public float DebugSpeedThroughPipe = 1f;
 
@@ -223,7 +224,8 @@ namespace GGJ2021
 
         public void MoveObjectThroughPipe(Transform trans, float speed, System.Action onFinish, StartingPoint startingPointEnum = StartingPoint.Auto)
         {
-            Debug.Log($"MoveObjectThroughPipe({trans}, {speed}, {startingPointEnum})");
+            if(EnableDebugLogs)
+                Debug.Log($"MoveObjectThroughPipe({trans}, {speed}, {startingPointEnum})");
             StartCoroutine(MoveObjectThroughPipeRoutine(trans, speed, onFinish, startingPointEnum));
         }
 

--- a/Assets/Scripts/Tilemap/Pipe.cs
+++ b/Assets/Scripts/Tilemap/Pipe.cs
@@ -223,6 +223,7 @@ namespace GGJ2021
 
         public void MoveObjectThroughPipe(Transform trans, float speed, System.Action onFinish, StartingPoint startingPointEnum = StartingPoint.Auto)
         {
+            Debug.Log($"MoveObjectThroughPipe({trans}, {speed}, {startingPointEnum})");
             StartCoroutine(MoveObjectThroughPipeRoutine(trans, speed, onFinish, startingPointEnum));
         }
 

--- a/Assets/Scripts/Util/CameraTracker.cs
+++ b/Assets/Scripts/Util/CameraTracker.cs
@@ -31,7 +31,8 @@
 
             target = player.position + offset;
 
-            float speed = Time.deltaTime * ((Mathf.Ceil(Vector2.Distance(this.transform.position, target))) + trackSpeed);
+            float speed = Time.deltaTime * ((Mathf.Ceil(Vector2.Distance(this.transform.position, target))) 
+                + (PlayerController.instance.goingThroughPipe ? PlayerController.instance.currentPipeSpeed : trackSpeed));
             if (target.x > leftBound.transform.position.x && target.x < rightBound.position.x)
                 this.transform.position = Vector3.MoveTowards(this.transform.position,
                     new Vector3(target.x, this.transform.position.y, this.transform.position.z), speed);


### PR DESCRIPTION
- CameraTracker uses PlayerController.currentPipeSpeed when PlayerController.goingThroughPipe is true
 - Requires us to set currentPIpeSpeed manually whenever we call Pipe.MoveObjectThroughPIpe
- Improved pipe logging